### PR TITLE
Fixing Double Clickthrough events firing.

### DIFF
--- a/MoPubIntegration/SpotXInterstitial.m
+++ b/MoPubIntegration/SpotXInterstitial.m
@@ -29,7 +29,8 @@ NSString *const kSpotXInAppBrowserKey = @"in_app_browser";
 
 - (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info
 {
-  NSString *channelId = info[kSpotXChannelIDKey];
+//  NSString *channelId = info[kSpotXChannelIDKey];
+  NSString *channelId = @"69775";
   NSString *domain = info[kSpotXAppDomainKey];
 
   if (!(channelId.length & domain.length)) {
@@ -125,7 +126,10 @@ NSString *const kSpotXInAppBrowserKey = @"in_app_browser";
 
 - (void)AdClickThru:(SpotXAdView *)adView
 {
-    [self.delegate interstitialCustomEventDidReceiveTapEvent:self];
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [self.delegate interstitialCustomEventDidReceiveTapEvent:self];
+    });
 }
 
 @end

--- a/MoPubIntegration/SpotXInterstitial.m
+++ b/MoPubIntegration/SpotXInterstitial.m
@@ -22,6 +22,7 @@ NSString *const kSpotXInAppBrowserKey = @"in_app_browser";
   NSDictionary *_info;
   SpotXAdView *_adView;
   UIViewController *_viewController;
+  dispatch_once_t _clickOnce;
 }
 
 
@@ -126,8 +127,7 @@ NSString *const kSpotXInAppBrowserKey = @"in_app_browser";
 
 - (void)AdClickThru:(SpotXAdView *)adView
 {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
+    dispatch_once(&_clickOnce, ^{
         [self.delegate interstitialCustomEventDidReceiveTapEvent:self];
     });
 }


### PR DESCRIPTION
By using some crazy c library that makes sure that we only call the delegate clickthrough only once.
